### PR TITLE
fix incident sharing with LTCs

### DIFF
--- a/csp-apps/rt/rt-adapter-emitter/src/main/java/com/fraunhofer/csp/rt/service/impl/EmitterDataHandlerImpl.java
+++ b/csp-apps/rt/rt-adapter-emitter/src/main/java/com/fraunhofer/csp/rt/service/impl/EmitterDataHandlerImpl.java
@@ -130,7 +130,7 @@ public class EmitterDataHandlerImpl implements EmitterDataHandler {
 		sharingParams.setIsExternal(false);
 
 		String sharing = incident.getSharing();
-		// LOG.debug("setToShare:" + sharing);
+		 LOG.debug("setToShare:" + sharing);
 
 		if (sharing.equalsIgnoreCase(CfSharing.DEFAULT_SHARING.toString())
 				|| sharing.toLowerCase().contains(CfSharing.DEFAULT_SHARING.toString().toLowerCase())) {
@@ -163,11 +163,16 @@ public class EmitterDataHandlerImpl implements EmitterDataHandler {
 			}
 
 			if (tcsandTeams != null && tcsandTeams.size() > 0) {
+				LOG.debug("tcsandTeams: {}", tcsandTeams.toString());
 				try {
 					// UAT FIX 4.4.2018 tcsIdlist = tcClient.getAllLocalTrustCircles().stream()
 					tcsIdlist = tcClient.getAllTrustCircles().stream()
 							.filter(tc -> tcsandTeams.contains(tc.getShortName())).map(TrustCircle::getId)
 							.collect(Collectors.toList());
+
+					tcsIdlist.addAll(tcClient.getAllLocalTrustCircles().stream()
+							.filter(tc -> tcsandTeams.contains(tc.getShortName())).map(TrustCircle::getId)
+							.collect(Collectors.toList()));
 				} catch (Exception e) {
 					LOG.error("getAllTrustCircle from TC failed with: ", e);
 					tcsIdlist = null;

--- a/csp-apps/rt/rt-adapter-emitter/src/main/java/com/fraunhofer/csp/rt/ticket/Ticket.java
+++ b/csp-apps/rt/rt-adapter-emitter/src/main/java/com/fraunhofer/csp/rt/ticket/Ticket.java
@@ -224,6 +224,7 @@ public class Ticket {
 		String sharing = "";
 		String sp = null;
 		sp = getCustomField(IncidentCustomFields.CF_SHARING_POLICY);
+		LOG.trace("getCustomField(IncidentCustomFields.CF_SHARING_POLICY): {}", getCustomField(IncidentCustomFields.CF_SHARING_POLICY));
 		if (sp.isEmpty() || sp.equalsIgnoreCase(CfSharing.NO_SHARING.toString())) {
 			LOG.debug("CustomField Sharing policy:NO_SHARING:" + sp);
 			sharing = CfSharing.NO_SHARING.toString();


### PR DESCRIPTION
It appears that RT was not taking LTCs in consideration when sharing, returning empty list (so CSP_ALL sharing)